### PR TITLE
SDAP 515 - Improved handling of unreachable remote SDAPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-493: 
   - Removed `resultSizeLimit` from /match_spark endpoint 
 ### Fixed
+- SDAP-515:
+  - Improved error handling with connections to remote SDAP deployments
 ### Security
 
 ## [1.2.0] - 2023-11-22

--- a/analysis/webservice/algorithms/DataSeriesList.py
+++ b/analysis/webservice/algorithms/DataSeriesList.py
@@ -68,10 +68,8 @@ class DataSeriesListCalcHandlerImpl(NexusCalcHandler):
                     )
                     del remote_collection['shortName']
                     current_collection.update(remote_collection)
-
-                except CollectionNotFound as e:
-                    logger.warning(e)
-                finally:
                     collection_list.append(current_collection)
+                except CollectionNotFound as e:
+                    logger.warning(e)                    
 
         return SimpleResult(collection_list)

--- a/analysis/webservice/redirect/RemoteSDAPCache.py
+++ b/analysis/webservice/redirect/RemoteSDAPCache.py
@@ -57,9 +57,9 @@ class RemoteSDAPCache:
         stripped_url = url.strip('/')
         if stripped_url not in self.sdap_lists or self.sdap_lists[stripped_url].outdated_at>datetime.now():
             self._add(stripped_url)
-
-        for collection in self.sdap_lists[stripped_url].list:
-            if 'shortName' in collection and collection['shortName'] == short_name:
-                return collection
-
+        if stripped_url in self.sdap_lists:
+            for collection in self.sdap_lists[stripped_url].list:
+                if 'shortName' in collection and collection['shortName'] == short_name:
+                    return collection
+        
         raise CollectionNotFound(f"collection {short_name} has not been found in url {stripped_url}")

--- a/analysis/webservice/redirect/RemoteSDAPCache.py
+++ b/analysis/webservice/redirect/RemoteSDAPCache.py
@@ -51,7 +51,7 @@ class RemoteSDAPCache:
             else:
                 raise CollectionNotFound(f"url {list_url} was not reachable, responded with status {r.status_code}")
         except CollectionNotFound as e:
-            logger.info(f'URL {url} is unreachable. Skipping. {e}')
+            logger.warning(e)
 
     def get(self, url, short_name):
         stripped_url = url.strip('/')
@@ -61,5 +61,5 @@ class RemoteSDAPCache:
             for collection in self.sdap_lists[stripped_url].list:
                 if 'shortName' in collection and collection['shortName'] == short_name:
                     return collection
-        
+
         raise CollectionNotFound(f"collection {short_name} has not been found in url {stripped_url}")

--- a/analysis/webservice/redirect/RemoteSDAPCache.py
+++ b/analysis/webservice/redirect/RemoteSDAPCache.py
@@ -38,7 +38,10 @@ class RemoteSDAPCache:
     def _add(self, url, timeout=2, max_age=3600*24):
         list_url = f"{url}/list"
         try:
-            r = requests.get(list_url, timeout=timeout)
+            try:
+                r = requests.get(list_url, timeout=timeout)
+            except Exception as e:
+                raise CollectionNotFound(f'URL {list_url} was not reachable')
             if r.status_code == 200:
                 logger.info("Caching list for sdap %s: %s", list_url, r.text)
                 self.sdap_lists[url] = RemoteSDAPList(
@@ -47,8 +50,8 @@ class RemoteSDAPCache:
                 )
             else:
                 raise CollectionNotFound(f"url {list_url} was not reachable, responded with status {r.status_code}")
-        except (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout) as e:
-            raise CollectionNotFound(f"url {list_url} was not reachable in {timeout} s")
+        except CollectionNotFound as e:
+            logger.info(f'URL {url} is unreachable. Skipping. {e}')
 
     def get(self, url, short_name):
         stripped_url = url.strip('/')


### PR DESCRIPTION
This fixes a bug where unreachable remote SDAPs could break the local SDAP calls to `/nexus/list`. Previously, only a few reasons for being unable to connect to the remote SDAP (like timeouts) were being caught, but there are a few additional edge cases to consider. We now check for anything other than a 200. We also needed to adjust the logic for how remote collections were added to the local `/nexus/list`. 

If the remote URL is unreachable, it is logged as a warning and moves on to trying the next remote collection.
ex:
```
2024-05-02T16:47:07 - webservice.redirect.RemoteSDAPCache - WARNING - URL https://aq-sdap.stcenter.net/nexus/list was not reachable
2024-05-02T16:47:07 - webservice.algorithms.DataSeriesList - WARNING - collection PM25 has not been found in url https://aq-sdap.stcenter.net/nexus
```
This has been tested on the AQ deployment with a known unreachable remote SDAP. 