### PR TITLE
[SDAP-525] Fix for expired AWS credentials for zarr collections breaking list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - Unreleased
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- SDAP-525: Fixed expired AWS creds for Zarr datasets breaking list endpoint
+### Security
+
 ## [1.3.0] - 2024-06-10
 ### Added
 - SDAP-506:

--- a/data-access/nexustiles/backends/zarr/backend.py
+++ b/data-access/nexustiles/backends/zarr/backend.py
@@ -123,14 +123,19 @@ class ZarrBackend(AbstractTileService):
         }
 
         if not simple:
-            min_date = self.get_min_time([])
-            max_date = self.get_max_time([])
-            ds['start'] = min_date
-            ds['end'] = max_date
-            ds['iso_start'] = datetime.utcfromtimestamp(min_date).strftime(ISO_8601)
-            ds['iso_end'] = datetime.utcfromtimestamp(max_date).strftime(ISO_8601)
+            try:
+                min_date = self.get_min_time([])
+                max_date = self.get_max_time([])
+                ds['start'] = min_date
+                ds['end'] = max_date
+                ds['iso_start'] = datetime.utcfromtimestamp(min_date).strftime(ISO_8601)
+                ds['iso_end'] = datetime.utcfromtimestamp(max_date).strftime(ISO_8601)
 
-            ds['metadata'] = dict(self.__ds.attrs)
+                ds['metadata'] = dict(self.__ds.attrs)
+            except Exception as e:
+                logger.error(f'Failed to access dataset for {self._name}. Cause: {e}')
+                ds['error'] = "Dataset is currently unavailable"
+                ds['error_reason'] = str(e)
 
         return [ds]
 


### PR DESCRIPTION
Replaced with error message in endpoint response.
Example:
```json
{
"shortName": "oco3_sams_l3_post_qf",
"title": "oco3_sams_l3_post_qf",
"type": "zarr",
"error": "Dataset is currently unavailable",
"error_reason": "Cannot open dataset (The AWS Access Key Id you provided does not exist in our records.)"
}
```