### PR TITLE
SDAP-526 - Upgrade canopy and ground masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SDAP-469: Support for three dimensional data. 2D data defaults to a layer at 0m elevation.
 - SDAP-492: Added some demo algorithms for working with and visualizing tomography data. Currently designed for data from airborne SAR campaigns, but can be readily generalized.
+  - SDAP-526: Upgrade 2D tomography endpoint canopy and ground masking feature to allow for primary and backup datasets
 - SDAP-497: Added tool to ease building of releases. Can build from ASF distributions, git repos, and local
 - SDAP-520: (Documentation) Added guide to docs for evaluating official release candidates.
 ### Changed


### PR DESCRIPTION
Update the ground and canopy ds arguments to allow 2 collection names, separated by commas. This allows users to specify, for example, a more accurate but less spatially complete (eg Lidar) as the "primary" masking dataset, along with a less accurate but spatially complete (ie, predicted heights from SAR-Lidar fusion) as a "secondary" or "backup" dataset to be used to fill the gaps of the primary. In the event that 2 datasets are specified, their heights are traced onto the output plot.