### PR TITLE
SDAP-521 Updated quickstart and test guide.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -143,7 +143,7 @@ To start Solr using a volume mount and expose the admin webapp on port 8983:
 
   export SOLR_DATA=~/nexus-quickstart/solr
   mkdir -p ${SOLR_DATA}
-  docker run --name solr --network sdap-net -v ${SOLR_DATA}/:/bitnami -p 8983:8983 -e SDAP_ZK_SERVICE_HOST="host.docker.internal" -d ${REPO}/sdap-solr-cloud:${SOLR_VERSION}
+  docker run --name solr --network sdap-net -v ${SOLR_DATA}/:/bitnami -p 8983:8983 -e ZK_HOST="host.docker.internal:2181/solr" -d ${REPO}/sdap-solr-cloud:${SOLR_VERSION}
 
 This will start an instance of Solr. To initialize it, we need to run the ``solr-cloud-init`` image.
 
@@ -215,7 +215,7 @@ Choose a location that is mountable by Docker (typically needs to be under the u
 
 .. code-block:: bash
 
-    export DATA_DIRECTORY=~/nexus-quickstart/data/avhrr-granules
+    export DATA_DIRECTORY=~/nexus-quickstart/data/
     mkdir -p ${DATA_DIRECTORY}
 
 .. _quickstart-step7:
@@ -290,7 +290,8 @@ Then go ahead and download 1 month worth of AVHRR netCDF files.
 
 .. code-block:: bash
 
-  cd $DATA_DIRECTORY
+  mkdir -p ${DATA_DIRECTORY}/avhrr-granules
+  cd $DATA_DIRECTORY/avhrr-granules
 
   curl -O https://raw.githubusercontent.com/apache/incubator-sdap-nexus/master/docs/granule-download.sh
   chmod 700 granule-download.sh
@@ -314,7 +315,7 @@ The collection configuration is a ``.yml`` file that tells the collection manage
   cat << EOF >> ${CONFIG_DIR}/collectionConfig.yml
   collections:
     - id: AVHRR_OI_L4_GHRSST_NCEI
-      path: /data/granules/*AVHRR_OI-GLOB-v02.0-fv02.0.nc
+      path: /data/granules/avhrr-granules/*AVHRR_OI-GLOB-v02.0-fv02.0.nc
       priority: 1
       forward-processing-priority: 5
       projection: Grid

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -143,7 +143,7 @@ To start Solr using a volume mount and expose the admin webapp on port 8983:
 
   export SOLR_DATA=~/nexus-quickstart/solr
   mkdir -p ${SOLR_DATA}
-  docker run --name solr --network sdap-net -v ${SOLR_DATA}/:/bitnami -p 8983:8983 -e ZK_HOST="host.docker.internal:2181/solr" -d ${REPO}/sdap-solr-cloud:${SOLR_VERSION}
+  docker run --name solr --network sdap-net -v ${SOLR_DATA}/:/bitnami -p 8983:8983 -e SOLR_ZK_HOSTS="host.docker.internal:2181" -e SOLR_ENABLE_CLOUD_MODE="yes" -d ${REPO}/sdap-solr-cloud:${SOLR_VERSION}
 
 This will start an instance of Solr. To initialize it, we need to run the ``solr-cloud-init`` image.
 

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -43,7 +43,7 @@ If you have not started the Collection Manager, start it now:
 
 .. code-block:: bash
 
-  docker run --name collection-manager --network sdap-net -v ${DATA_DIRECTORY}:/data/granules/ -v $(pwd):/home/ingester/config/ -e COLLECTIONS_PATH="/home/ingester/config/test_collections.yaml" -e HISTORY_URL="http://host.docker.internal:8983/" -e RABBITMQ_HOST="host.docker.internal:5672" -e RABBITMQ_USERNAME="user" -e RABBITMQ_PASSWORD="bitnami" -d ${REPO}/sdap-collection-manager:${COLLECTION_MANAGER_VERSION}
+  docker run --name collection-manager --network sdap-net -v ${DATA_DIRECTORY}:/data/granules/ -v ${CONFIG_DIR}:/home/ingester/config/ -e COLLECTIONS_PATH="/home/ingester/config/collectionConfig.yml" -e HISTORY_URL="http://host.docker.internal:8983/" -e RABBITMQ_HOST="host.docker.internal:5672" -e RABBITMQ_USERNAME="user" -e RABBITMQ_PASSWORD="bitnami" -d ${REPO}/sdap-collection-manager:${COLLECTION_MANAGER_VERSION}
 
 Refer to the :ref:`Quickstart Guide<quickstart>` to see how many files are enqueued for ingest, there should be 207 total.
 (This may appear to be less if you have ingesters running. We recommend not starting the ingesters until all data is queued.

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,7 @@
 ### To run:
 
 ```shell
-pytest test_cdms.py --with-integration [--force-subset]
+pytest test_sdap.py --with-integration [--force-subset]
 ```
 
 ### Options

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,9 @@
 pandas
 pytest
+pytest-integration
 requests
 beautifulsoup4
 python-dateutil
 pytz
 shapely
+geopy


### PR DESCRIPTION
Tested https://github.com/apache/sdap-nexus/pull/325 with local build of SDAP v1.3.0 and found the following issues

1. Solr failed to start in cloud mode. Setting `ZK_HOST="host.docker.internal:2181/solr"` seemed to fix that issue.

2. When testing satellite-to-satellite matchup got the following error message

```
future: <Future finished exception=InvalidRequest('Error from server: code=2200 [Invalid query] message="Undefined column name message"')>
Traceback (most recent call last):
  File "/opt/python/3.9.7/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/incubator-sdap-nexus/analysis/webservice/algorithms_spark/Matchup.py", line 291, in async_calc
    storage.updateExecution(
  File "/incubator-sdap-nexus/analysis/webservice/algorithms/doms/ResultsStorage.py", line 129, in updateExecution
    self.__updateExecution(execution_id, completeTime, status, message)
  File "/incubator-sdap-nexus/analysis/webservice/algorithms/doms/ResultsStorage.py", line 145, in __updateExecution
    self._session.execute(cql, (complete_time, status, message, execution_id))
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/cassandra/cluster.py", line 2618, in execute
    return self.execute_async(query, parameters, trace, custom_payload, timeout, execution_profile, paging_state, host, execute_as).result()
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/cassandra/cluster.py", line 4877, in result
    raise self._final_exception
cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="Undefined column name message"
```

3. The following tests failed

- FAILED test_sdap.py::test_version - assert 500 == 200

```
2024-10-15T06:30:29 - tornado.application - ERROR - Uncaught exception GET /version (192.168.65.1)
HTTPServerRequest(protocol='http', host='localhost:8083', method='GET', uri='/version', version='HTTP/1.1', remote_ip='192.168.65.1')
Traceback (most recent call last):
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/tornado/web.py", line 1702, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/incubator-sdap-nexus/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py", line 34, in get
    self.write(pkg_resources.get_distribution("nexusanalysis").version)
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 534, in get_distribution
    dist = get_provider(dist)
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 417, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1070, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 897, in resolve
    dist = self._resolve_dist(
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/pkg_resources/__init__.py", line 938, in _resolve_dist
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'nexusanalysis' distribution was not found and is required by the application
2024-10-15T06:30:29 - tornado.access - ERROR - 500 GET /version (192.168.65.1) 44.58ms
```

- FAILED test_sdap.py::test_heartbeat - assert 500 == 200

```
2024-10-15T06:31:34 - nexus - INFO - Received request GET /heartbeat (192.168.65.1)
2024-10-15T06:31:34 - nexustiles.nexustiles - INFO - use config file config/datasets.ini.default
2024-10-15T06:31:34 - nexustiles.nexustiles - INFO - use config file config/datasets.ini
2024-10-15T06:31:34 - nexus - ERROR - Error processing request
Traceback (most recent call last):
  File "/incubator-sdap-nexus/analysis/webservice/nexus_tornado/request/handlers/NexusRequestHandler.py", line 54, in get
    results = yield io_loop.run_in_executor(
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/opt/python/3.9.7/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/incubator-sdap-nexus/analysis/webservice/algorithms/Heartbeat.py", line 32, in calc
    solrOnline = self._get_tile_service().pingSolr()
AttributeError: 'NexusTileService' object has no attribute 'pingSolr'
2024-10-15T06:31:34 - tornado.access - ERROR - 500 GET /heartbeat (192.168.65.1) 20.01ms
```

- FAILED test_sdap.py::test_match_spark[gridded_to_gridded-1058] - AssertionError: Incorrect count: Expected 1058, got 1000
- FAILED test_sdap.py::test_match_spark[swath_to_swath-4026] - AssertionError: Incorrect count: Expected 4026, got 1000

4. test_cdmssubset_L2 succeeds, but could not run test_subset_L2 without nexus-webapp crashing altogether. Is there specific resource requirement for this test? 


