### PR TITLE
SDAP-527 - Fixed creation of execution status Cassandra table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - SDAP-525: Fixed expired AWS creds for Zarr datasets breaking list endpoint
+- SDAP-527: Fixed incorrect initialization of `doms.doms_executions` Cassandra table, which broke `/matchup` endpoint for new installations.
 ### Security
 
 ## [1.3.0] - 2024-06-10

--- a/analysis/webservice/algorithms/doms/DomsInitialization.py
+++ b/analysis/webservice/algorithms/doms/DomsInitialization.py
@@ -120,7 +120,8 @@ class DomsInitializer:
               time_started timestamp,
               time_completed timestamp,
               user_email text,
-              status text
+              status text,
+              message text
             );
                 """
         session.execute(cql)


### PR DESCRIPTION
Initial `CREATE` statement omitted the `message` field that was added in #249, so it is added in this PR. I leave testing to this to @ngachung's evaluation of #325, where this issue was found.

This PR should fix the following error:
```
future: <Future finished exception=InvalidRequest('Error from server: code=2200 [Invalid query] message="Undefined column name message"')>
Traceback (most recent call last):
  File "/opt/python/3.9.7/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/incubator-sdap-nexus/analysis/webservice/algorithms_spark/Matchup.py", line 291, in async_calc
    storage.updateExecution(
  File "/incubator-sdap-nexus/analysis/webservice/algorithms/doms/ResultsStorage.py", line 129, in updateExecution
    self.__updateExecution(execution_id, completeTime, status, message)
  File "/incubator-sdap-nexus/analysis/webservice/algorithms/doms/ResultsStorage.py", line 145, in __updateExecution
    self._session.execute(cql, (complete_time, status, message, execution_id))
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/cassandra/cluster.py", line 2618, in execute
    return self.execute_async(query, parameters, trace, custom_payload, timeout, execution_profile, paging_state, host, execute_as).result()
  File "/incubator-sdap-nexus/.venv/lib/python3.9/site-packages/cassandra/cluster.py", line 4877, in result
    raise self._final_exception
cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="Undefined column name message"
```