### PR TITLE
SDAP-529 - Added configuration for verbose logging for collection manager in the Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - SDAP-526: Upgrade 2D tomography endpoint canopy and ground masking feature to allow for primary and backup datasets
 - SDAP-497: Added tool to ease building of releases. Can build from ASF distributions, git repos, and local
 - SDAP-520: (Documentation) Added guide to docs for evaluating official release candidates.
+- SDAP-529: Added configuration for verbose logging for collection manager in the Helm chart
 ### Changed
 - SDAP-470: Modified `cdms-reader` tool to support primary to secondary matchups
 ### Deprecated

--- a/helm/templates/collection-manager.yml
+++ b/helm/templates/collection-manager.yml
@@ -64,6 +64,10 @@ spec:
               value: {{ $value }}
             {{- end }}
             {{- end }}
+            {{- if .Values.ingestion.collectionManager.verbose }}
+            - name: LOG_LEVEL
+              value: DEBUG
+            {{- end }}
           resources:
             requests:
               cpu: {{ .Values.ingestion.collectionManager.cpu }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -64,6 +64,9 @@ ingestion:
     ## memory refers to both request and limit
     memory: 0.5Gi
 
+    ## Enable verbose logging
+    verbose: false
+
   configOperator:
     image: nexusjpl/config-operator:0.0.1
 


### PR DESCRIPTION
Simple tweak to add an option to pass `LOG_LEVEL=DEBUG` env variable to the collection manager pod in k8s deployments